### PR TITLE
fixed syntax errors related to tvWidget.createButton()

### DIFF
--- a/react-typescript/src/components/TVChartContainer/index.tsx
+++ b/react-typescript/src/components/TVChartContainer/index.tsx
@@ -77,18 +77,17 @@ export class TVChartContainer extends React.PureComponent<Partial<ChartContainer
 		this.tvWidget = tvWidget;
 
 		tvWidget.onChartReady(() => {
-			const button = tvWidget.createButton()
-				.attr('title', 'Click to show a notification popup')
-				.addClass('apply-common-tooltip')
-				.on('click', () => tvWidget.showNoticeDialog({
+			const button = tvWidget.createButton();
+			button.setAttribute('title', 'Click to show a notification popup');
+			button.setAttribute('class', 'apply-common-tooltip');
+			button.addEventListener('click', () => tvWidget.showNoticeDialog({
 					title: 'Notification',
 					body: 'TradingView Charting Library API works correctly',
 					callback: () => {
 						console.log('Noticed!');
 					},
 				}));
-
-			button[0].innerHTML = 'Check API';
+			button.innerHTML = 'Check API';
 		});
 	}
 


### PR DESCRIPTION
#### Add example checklist

- [x] **Any** commit does not contain the charting library's code
- [ ] Addresses an existing issue: #00000
- [ ] The example is added to README.md
- [x] The example is self-sufficient and contains only necessary files/changes

#### Bug fix checklist

- [x] **Any** commit does not contain the charting library's code
- [ ] Addresses an existing issue: #00000


----------------------------
I was getting the following error with the current code in master:
```
Property 'attr' does not exist on type 'HTMLElement'
```
My commit fixes this problem