### PR TITLE
[react-typescript] Added unit tests

### DIFF
--- a/react-typescript/package.json
+++ b/react-typescript/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "start": "react-scripts-ts start",
-    "build": "react-scripts-ts build"
+    "build": "react-scripts-ts build",
+    "test": "react-scripts-ts test"
   },
   "devDependencies": {
     "@types/jquery": "^1.10.31",

--- a/react-typescript/src/App.test.tsx
+++ b/react-typescript/src/App.test.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import App from './App';
+import { TVChartContainer } from './components/TVChartContainer';
+
+test('basic', () => {
+	expect(<App />).toBeDefined();
+	expect(<TVChartContainer />).toBeDefined();
+});

--- a/react-typescript/src/setupTests.ts
+++ b/react-typescript/src/setupTests.ts
@@ -1,0 +1,2 @@
+// @ts-ignore
+global.window = {};

--- a/react-typescript/tsconfig.test.json
+++ b/react-typescript/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "jsx": "react"
+  }
+}


### PR DESCRIPTION
It was not possible to run unit tests from the react typescript project.
This commit adds the minimum setup to get started.