### PR TITLE
Do not try to load polyfills in react examples

### DIFF
--- a/react-javascript/public/index.html
+++ b/react-javascript/public/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8">
-		<script src="%PUBLIC_URL%/datafeeds/udf/dist/polyfills.js"></script>
 		<script src="%PUBLIC_URL%/datafeeds/udf/dist/bundle.js"></script>
 		<title>Charting Library React Demo</title>
 	</head>

--- a/react-typescript/public/index.html
+++ b/react-typescript/public/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8">
-		<script src="%PUBLIC_URL%/datafeeds/udf/dist/polyfills.js"></script>
 		<script src="%PUBLIC_URL%/datafeeds/udf/dist/bundle.js"></script>
 		<title>Charting Library React Demo</title>
 	</head>


### PR DESCRIPTION

#### Bug fix checklist

- [x] **Any** commit does not contain the charting library's code
- [x] Addresses an existing issue: #261

Fixes #261 