### PR TITLE
fix: access to chart via direct url bug fixed.

### DIFF
--- a/nextjs/pages/_document.tsx
+++ b/nextjs/pages/_document.tsx
@@ -1,15 +1,13 @@
 import { Html, Head, Main, NextScript } from "next/document";
 
 export default function Document() {
-    return (
-        <Html lang="en">
-            <Head>
-                <script src="/static/datafeeds/udf/dist/bundle.js" async />
-            </Head>
-            <body>
-                <Main />
-                <NextScript />
-            </body>
-        </Html>
-    );
+  return (
+    <Html lang="en">
+      <Head></Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
 }

--- a/nextjs/pages/index.tsx
+++ b/nextjs/pages/index.tsx
@@ -1,32 +1,47 @@
 import Head from "next/head";
-import { TVChartContainer } from "@/components/TVChartContainer";
+import dynamic from "next/dynamic";
+import { useState } from "react";
+import Script from "next/script";
+
 import {
-    ChartingLibraryWidgetOptions,
-    ResolutionString,
+  ChartingLibraryWidgetOptions,
+  ResolutionString,
 } from "@/public/static/charting_library/charting_library";
 
 const defaultWidgetProps: Partial<ChartingLibraryWidgetOptions> = {
-    symbol: "AAPL",
-    interval: "1D" as ResolutionString,
-    library_path: "/static/charting_library/",
-    locale: "en",
-    charts_storage_url: "https://saveload.tradingview.com",
-    charts_storage_api_version: "1.1",
-    client_id: "tradingview.com",
-    user_id: "public_user_id",
-    fullscreen: false,
-    autosize: true,
+  symbol: "AAPL",
+  interval: "1D" as ResolutionString,
+  library_path: "/static/charting_library/",
+  locale: "en",
+  charts_storage_url: "https://saveload.tradingview.com",
+  charts_storage_api_version: "1.1",
+  client_id: "tradingview.com",
+  user_id: "public_user_id",
+  fullscreen: false,
+  autosize: true,
 };
 
+const TVChartContainer = dynamic(
+  () =>
+    import("@/components/TVChartContainer").then((mod) => mod.TVChartContainer),
+  { ssr: false }
+);
+
 export default function Home() {
-    return (
-        <>
-            <Head>
-                <title>TradingView Charting Library and Next.js</title>
-            </Head>
-            <main>
-                <TVChartContainer {...defaultWidgetProps} />
-            </main>
-        </>
-    );
+  const [isScriptReady, setIsScriptReady] = useState(false);
+  return (
+    <>
+      <Head>
+        <title>TradingView Charting Library and Next.js</title>
+      </Head>
+      <Script
+        src="/static/datafeeds/udf/dist/bundle.js"
+        strategy="lazyOnload"
+        onLoad={() => {
+          setIsScriptReady(true);
+        }}
+      />
+      {isScriptReady && <TVChartContainer {...defaultWidgetProps} />}
+    </>
+  );
 }


### PR DESCRIPTION
It was not possible to access the chart page through a direct link and the following error occurred :
"**Cannot read property 'UDFCompatibleDatafeed' of undefined**"
This problem was solved by using the <Script /> with "lazyOnload" strategy , "dynamic import" and react "useState" hook.