### PR TITLE
fix: correct useRef type and container type casting

### DIFF
--- a/nextjs/components/TVChartContainer/index.tsx
+++ b/nextjs/components/TVChartContainer/index.tsx
@@ -3,8 +3,7 @@ import { useEffect, useRef } from "react";
 import { ChartingLibraryWidgetOptions, LanguageCode, ResolutionString, widget } from "@/public/static/charting_library";
 
 export const TVChartContainer = (props: Partial<ChartingLibraryWidgetOptions>) => {
-	const chartContainerRef =
-		useRef<HTMLDivElement>() as React.MutableRefObject<HTMLInputElement>;
+	cconst chartContainerRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		const widgetOptions: ChartingLibraryWidgetOptions = {
@@ -19,7 +18,7 @@ export const TVChartContainer = (props: Partial<ChartingLibraryWidgetOptions>) =
 				}
 			),
 			interval: props.interval as ResolutionString,
-			container: chartContainerRef.current,
+			container: chartContainerRef.current as HTMLElement,
 			library_path: props.library_path,
 			locale: props.locale as LanguageCode,
 			disabled_features: ["use_localstorage_for_settings"],


### PR DESCRIPTION
#### Add example checklist

- [x] **Any** commit does not contain the charting library's code
- [x] The example is self-sufficient and contains only necessary files/changes

#### Bug fix checklist

- [x] **Any** commit does not contain the charting library's code
- [x] Addresses an existing issue: #00000


#### Description

when run `npm run build`,the terminal shows:

```bash
    Linting and checking validity of types  ...Failed to compile.
    
    ./components/TVChartContainer/index.tsx:7:3
    Type error: Expected 1 arguments, but got 0.
    
       5 | export const TVChartContainer = (props: Partial<ChartingLibraryWidgetOptions>) => {
       6 |  const chartContainerRef =
    >  7 |          useRef<HTMLDivElement>() as React.MutableRefObject<HTMLInputElement>;
         |          ^
       8 |
       9 |  useEffect(() => {
      10 |          const widgetOptions: ChartingLibraryWidgetOptions = {
    Static worker exited with code: 1 and signal: null
```


#### New Behavior
`npm run build` works well,no typescript problem anymore